### PR TITLE
Explicitly set the package access to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     }
   },
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "dependencies": {
     "@restless/sanitizers": "^0.2.5",


### PR DESCRIPTION
The last package release failed because it considered it as a private package: https://github.com/0xarc-io/analytics-sdk/actions/runs/10272421713/job/28424596741

Explicitly setting the publish config to `public` should fix the issue: https://stackoverflow.com/questions/45820881/npm-publish-failed-put-402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for public access during package publishing, enhancing accessibility for users.

- **Documentation**
	- Updated package metadata to provide clearer instructions regarding accessibility upon publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->