### PR TITLE
Rename ARCx to 0xArc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![npm version](https://badge.fury.io/js/@arcxmoney%2Fanalytics.svg)](https://badge.fury.io/js/@arcxmoney%2Fanalytics) [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-> The ARCx Analytics SDK is a simple SDK that helps provide higher fidelity analytics by merging on-chain data with off-chain data from front-ends. We value user privacy and do not collect IP addresses or scrape any information without your permission.
+> The 0xArc Analytics SDK is a simple SDK that helps provide higher fidelity analytics by merging on-chain data with off-chain data from front-ends. We value user privacy and do not collect IP addresses or scrape any information without your permission.
 
 # Installation Guide
 
@@ -26,9 +26,9 @@ Add the following to your `index.html`:
 </script>
 ```
 
-That’s it! The ARCx SDK will automatically detect wallet connections, referrer data, button clicks, page tracks and transactions that occur on your front-end.
+That’s it! The 0xArc SDK will automatically detect wallet connections, referrer data, button clicks, page tracks and transactions that occur on your front-end.
 
-You will now have access to the ARCx SDK instance via `window.arcx` anywhere in the app, in case you want to use any specific functionality described in the [API section below](#api).
+You will now have access to the 0xArc SDK instance via `window.arcx` anywhere in the app, in case you want to use any specific functionality described in the [API section below](#api).
 
 ## Option 2 (via React Component)
 
@@ -46,36 +46,31 @@ or
 npm install @arcxmoney/analytics --save
 ```
 
-
-
 2. Use the `ArcxAnalyticsProvider` anywhere at the top of your component tree.
 
 ```jsx
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { ArcxAnalyticsProvider } from '@arcxmoney/analytics';
-import App from './App'; // Import your main App component
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { ArcxAnalyticsProvider } from '@arcxmoney/analytics'
+import App from './App' // Import your main App component
 
-const apiKey = "YOUR_API_KEY"; // Replace with your actual ARCx analytics API key
+const apiKey = 'YOUR_API_KEY' // Replace with your actual 0xArc analytics API key
 
 const RootComponent = () => (
   <ArcxAnalyticsProvider apiKey={apiKey}>
     <App />
   </ArcxAnalyticsProvider>
-);
+)
 
-ReactDOM.render(<RootComponent />, document.getElementById('root'));
-
+ReactDOM.render(<RootComponent />, document.getElementById('root'))
 ```
-
-
 
 3. Track wallet connection events whenever a wallet is connected
 
 ```jsx
 const WalletConnectionTracker = () => {
-  const { account, chainId } = useWeb3React();
-  const sdk = useArcxAnalytics();
+  const { account, chainId } = useWeb3React()
+  const sdk = useArcxAnalytics()
 
   useEffect(() => {
     if (account && chainId) {
@@ -83,30 +78,27 @@ const WalletConnectionTracker = () => {
       sdk.wallet({
         chainId,
         account,
-      });
+      })
     }
-  }, [account, chainId, sdk]); // Re-run this effect if account or chainId changes
+  }, [account, chainId, sdk]) // Re-run this effect if account or chainId changes
 
-  return <div>Tracking wallet connections with useWeb3React.</div>;
-};
-
+  return <div>Tracking wallet connections with useWeb3React.</div>
+}
 ```
-
-
 
 4. Track transactions
 
 ```jsx
 const TransactionButton = () => {
-  const { account, chainId } = useWeb3React();
-  const arcxAnalytics = useArcxAnalytics();
+  const { account, chainId } = useWeb3React()
+  const arcxAnalytics = useArcxAnalytics()
 
   const handleTransactionSubmit = async () => {
     // Example: Simulating a transaction call
     // In a real scenario, you would replace this with your transaction logic,
     // for example, using ethers.js or web3.js to interact with a smart contract
-    
-    const transactionHash = '0x023c0e7...'; // Placeholder for the actual transaction hash
+
+    const transactionHash = '0x023c0e7...' // Placeholder for the actual transaction hash
 
     // Assuming the transaction was successful and you have the hash
     // Now, track the transaction using the analytics SDK
@@ -118,35 +110,28 @@ const TransactionButton = () => {
         // Example metadata
         action: 'User Initiated Transaction',
       },
-    });
+    })
 
-    console.log('Transaction tracked!');
-  };
+    console.log('Transaction tracked!')
+  }
 
-  return (
-    <button onClick={handleTransactionSubmit}>Submit Transaction</button>
-  );
-};
-
+  return <button onClick={handleTransactionSubmit}>Submit Transaction</button>
+}
 ```
-
-
 
 You are now ready to go! For additional methods supported, please see below.
 
 #### Available SDK methods
 
-| Method          | Parameters                                                   | Description                                                  |
-| --------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| `wallet`        | - `chainId`: string or number<br />- `account`: string       | Track a wallet connection event                              |
-| `chain`         | - `chainId`: string or number<br />- `account`: string (optional). Will use the `account` value in the `wallet()` call if not passed | Track a chain changed event                                  |
-| `transaction`   | - `transactionHash`: string<br />- `account`: string (optional). Will use the `account` value in the `wallet()` call if not passed<br />- `chainId`: string or number (optional). If not provided, the previously recorded chainID will be used<br />- `metadata`: dictionary (optional). This is additional information about the transaction you might want to pass | Track a transaction event                                    |
-| `signature`     | - `message`: string - message that was signed<br />- `signatureHash`: string (optional)<br />- `account`: string. Will use the `account` value in the `wallet()` call if not passed | Track a signature transaction                                |
-| `disconnection` | - `account`: string (optional). The disconnected account. Will use the previously recorded account if not passed<br />- `chainId`: string or number (optional). Will use the previously recorded chain ID if not passed. | Track a wallet disconnection event.                          |
-| `event`         | - `name`: string. The name of the event<br />- `attributes`: dictionary (optional) | Track a custom event                                         |
-| `page`          |                                                              | Track a page view (current page). Note that you only have to call this if `trackPages` is set to `false` in the config. |
-
-
+| Method          | Parameters                                                                                                                                                                                                                                                                                                                                                            | Description                                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `wallet`        | - `chainId`: string or number<br />- `account`: string                                                                                                                                                                                                                                                                                                                | Track a wallet connection event                                                                                         |
+| `chain`         | - `chainId`: string or number<br />- `account`: string (optional). Will use the `account` value in the `wallet()` call if not passed                                                                                                                                                                                                                                  | Track a chain changed event                                                                                             |
+| `transaction`   | - `transactionHash`: string<br />- `account`: string (optional). Will use the `account` value in the `wallet()` call if not passed<br />- `chainId`: string or number (optional). If not provided, the previously recorded chainID will be used<br />- `metadata`: dictionary (optional). This is additional information about the transaction you might want to pass | Track a transaction event                                                                                               |
+| `signature`     | - `message`: string - message that was signed<br />- `signatureHash`: string (optional)<br />- `account`: string. Will use the `account` value in the `wallet()` call if not passed                                                                                                                                                                                   | Track a signature transaction                                                                                           |
+| `disconnection` | - `account`: string (optional). The disconnected account. Will use the previously recorded account if not passed<br />- `chainId`: string or number (optional). Will use the previously recorded chain ID if not passed.                                                                                                                                              | Track a wallet disconnection event.                                                                                     |
+| `event`         | - `name`: string. The name of the event<br />- `attributes`: dictionary (optional)                                                                                                                                                                                                                                                                                    | Track a custom event                                                                                                    |
+| `page`          |                                                                                                                                                                                                                                                                                                                                                                       | Track a page view (current page). Note that you only have to call this if `trackPages` is set to `false` in the config. |
 
 ## Option 3 (via manual instantiation)
 
@@ -166,8 +151,6 @@ or
 npm install @arcxmoney/analytics --save
 ```
 
-
-
 2. Initialize the SDK and keep an instance of it ready to reference in other parts of your app. To do this, add the following code on your app’s load:
 
 ```jsx
@@ -180,11 +163,7 @@ const sdk = await ArcxAnalyticsSdk.init(API_KEY, {
 })
 ```
 
-
-
 3. Track the blockchain-related and custom events you want using the method list from step 2 above.
-
-
 
 # SDK Configuration
 
@@ -192,15 +171,15 @@ Regardless of which installation method you choose, you can disable any automati
 
 The configuration options are:
 
-| Config key               | Type    | Description                                                                                         | Default |
-| ------------------------ | ------- | --------------------------------------------------------------------------------------------------- | ------- |
-| `cacheIdentity`          | boolean | Caches the identity of users in the browser's local storage to capture cross-session behaviours     | `true`  |
-| `trackPages`             | boolean | Tracks whenever there is a URL change during the session and logs it automatically.                 | `true`  |
-| `trackWalletConnections` | boolean | Automatically track wallet connections (Metamask only)                                              | `true`  |
-| `trackChainChanges`      | boolean | Automatically track chain ID changes (Metamask only)                                                | `true`  |
-| `trackTransactions`      | boolean | Automatically track transaction requests (Metamask only)                                            | `true`  |
-| `trackSigning`           | boolean | Automatically track signing requests (Metamask only)                                                | `true`  |
-| `trackClicks`            | boolean | Automatically track click events                                                                    | `true`  |
+| Config key               | Type    | Description                                                                                     | Default |
+| ------------------------ | ------- | ----------------------------------------------------------------------------------------------- | ------- |
+| `cacheIdentity`          | boolean | Caches the identity of users in the browser's local storage to capture cross-session behaviours | `true`  |
+| `trackPages`             | boolean | Tracks whenever there is a URL change during the session and logs it automatically.             | `true`  |
+| `trackWalletConnections` | boolean | Automatically track wallet connections (Metamask only)                                          | `true`  |
+| `trackChainChanges`      | boolean | Automatically track chain ID changes (Metamask only)                                            | `true`  |
+| `trackTransactions`      | boolean | Automatically track transaction requests (Metamask only)                                        | `true`  |
+| `trackSigning`           | boolean | Automatically track signing requests (Metamask only)                                            | `true`  |
+| `trackClicks`            | boolean | Automatically track click events                                                                | `true`  |
 
 # API
 
@@ -214,12 +193,12 @@ options.
 
 **Parameters:**
 
-- `apiKey` **(string)** - the ARCx-provided API key.
+- `apiKey` **(string)** - the 0xArc-provided API key.
 - `config` **(object)** - overrides of the SDK configuration [above](#sdk-configuration).
 
 ```js
 await analytics = await ArcxAnalyticsSdk.init(
-  YOUR_API_KEY, // The ARCx-provided API key
+  YOUR_API_KEY, // The 0xArc-provided API key
   {
     cacheIdentity: true,
     trackReferrer: true,
@@ -304,7 +283,7 @@ await analytics.disconnection({
 
 ### `chain`
 
-Logs when there is a change in the blockchain the user’s wallet is connected to. This function is instrumental in tracking user behaviour associated with different chains, facilitating a richer analysis in your ARCx analytics setup.
+Logs when there is a change in the blockchain the user’s wallet is connected to. This function is instrumental in tracking user behaviour associated with different chains, facilitating a richer analysis in your 0xArc analytics setup.
 
 **Parameters:**
 
@@ -363,7 +342,7 @@ await analytics.signature({
 
 We do not support automatic wallet activity tracking with wallets other than Metamask.
 
-Unless your dApp uses *only* Metamask, you need to either use the installation option 2 or 3.
+Unless your dApp uses _only_ Metamask, you need to either use the installation option 2 or 3.
 
 # Development notes
 
@@ -372,5 +351,5 @@ To run a local version of the script:
 1. Run `yarn build` at the root level to build the script.
 2. Run `yarn copy-build-example` to copy the built contents into the `example/cra-script-tag` project.
 3. Make a copy of `.env.example` and rename it to `.env` in the `example/cra-script-tag` folder.
-4. Make sure to add your ARCx API + Alchemy keys to the `.env` file (find `YOUR_KEY_HERE`).
+4. Make sure to add your 0xArc API + Alchemy keys to the `.env` file (find `YOUR_KEY_HERE`).
 5. Run `cd example/cra-script-tag && yarn && yarn start` to start the example app.

--- a/example/cra-provider/README.md
+++ b/example/cra-provider/README.md
@@ -1,6 +1,6 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-# Usage of ARCx Analytics React Provider
+# Usage of 0xArc Analytics React Provider
 
 If you have a React app, one easy way to integrate the SDK is to simply add the `ArcxAnalyticsProvider` at the root of your application:
 

--- a/example/cra-provider/public/index.html
+++ b/example/cra-provider/public/index.html
@@ -5,10 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -24,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ARCx Analytics Example</title>
+    <title>0xArc Analytics Example</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/example/cra-provider/src/App.tsx
+++ b/example/cra-provider/src/App.tsx
@@ -59,7 +59,7 @@ function App() {
       <div className="container mx-auto">
         <div className="flex flex-col justify-center items-center mt-24 gap-4">
           <h1 className="text-5xl font-bold">
-            ARCx Analytics Example Page |{' '}
+            0xArc Analytics Example Page |{' '}
             <span>
               <Routes>
                 <Route path="/" element="Home" />
@@ -70,7 +70,7 @@ function App() {
             </span>
           </h1>
           <p className="text-center">
-            Welcome to the ARCx Analytics example page!
+            Welcome to the 0xArc Analytics example page!
             <br />
             Click on the buttons below to change routes and fire events. You can observe what is
             being sent to the API below

--- a/example/cra-script-tag/.env.example
+++ b/example/cra-script-tag/.env.example
@@ -5,5 +5,5 @@ REACT_APP_ALCHEMY_KEY_GOERLI = YOUR_KEY_HERE # Alchemy key for goerli
 
 
 # Optional
-REACT_APP_ARCX_API_URL = # ARCx Developer option, used for local api testing
-REACT_APP_ARCX_USE_LOCAL_BUILD = # ARCx Developer option, used for local sdk testing
+REACT_APP_ARCX_API_URL = # 0xArc Developer option, used for local api testing
+REACT_APP_ARCX_USE_LOCAL_BUILD = # 0xArc Developer option, used for local sdk testing

--- a/example/cra-script-tag/README.md
+++ b/example/cra-script-tag/README.md
@@ -1,12 +1,12 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-# Usage of ARCx Analytics through a script tag
+# Usage of 0xArc Analytics through a script tag
 
 Simply add the following script in the header of your application:
 
 ```html
 <script>
-  const script = document.createElement('script');
+  const script = document.createElement('script')
   const apiKey = YOUR_API_KEY
   script.src = 'https://unpkg.com/@arcxmoney/analytics'
   script.onload = function () {

--- a/example/cra-script-tag/public/index.html
+++ b/example/cra-script-tag/public/index.html
@@ -12,7 +12,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!-- ARCx Analytics -->
+    <!-- 0xArc Analytics -->
     <script>
       const script = document.createElement('script')
       const apiKey = '%REACT_APP_ARCX_API_KEY%'
@@ -42,7 +42,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>ARCx Analytics Example</title>
+    <title>0xArc Analytics Example</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/example/cra-script-tag/src/App.tsx
+++ b/example/cra-script-tag/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
           <div className="container mx-auto">
             <div className="flex flex-col justify-center items-center mt-24 gap-4">
               <h1 className="text-5xl font-bold">
-                ARCx Analytics Example Page |{' '}
+                0xArc Analytics Example Page |{' '}
                 <span>
                   <Routes>
                     <Route path="/" element="Home" />
@@ -71,7 +71,7 @@ function App() {
                 </span>
               </h1>
               <p className="text-center">
-                Welcome to the ARCx Analytics example page!
+                Welcome to the 0xArc Analytics example page!
                 <br />
                 Click on the buttons below to change routes and fire events. You can observe what is
                 being sent to the API below


### PR DESCRIPTION
Update references of `ARCx` to `0xArc` in the Readme (and some other places) to keep consistancy with the new  org change. This doesn't require a package deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Rebranding of the SDK and its associated documentation from "ARCx" to "0xArc."
	- Updated titles and references in example projects to reflect the new branding.
- **Documentation**
	- Revised README files and comments to replace "ARCx" with "0xArc" for consistency.
	- Improved readability in various documentation files with minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->